### PR TITLE
Enable data readers consistently

### DIFF
--- a/src/cprop/source.cljc
+++ b/src/cprop/source.cljc
@@ -13,6 +13,7 @@
 
 (defn read-config [input]
   (edn/read-string
+    {:readers *data-readers*}
     (slurp input)))
 
 (defn- k->path [k dash level]
@@ -33,7 +34,7 @@
     (re-matches #"\w+" v) v
     :else
     (try
-      (let [parsed (edn/read-string v)]
+      (let [parsed (edn/read-string {:readers *data-readers*} v)]
         (if (symbol? parsed)
           v
           parsed))


### PR DESCRIPTION
I think it would make sense to use `*data-readers*` when reading from files and from env-vars etc, as well as from resources (as enabled in #14)