### PR TITLE
Parse numeric string using `bigint` if too big for Long

### DIFF
--- a/dev-resources/fill-me-in.edn
+++ b/dev-resources/fill-me-in.edn
@@ -12,6 +12,6 @@
                      :conn-req-timeout 600000
                      :max-total 200
                      :max-per-route :ME-ALSO}}}
-
+  :some-big-int :I-SHOULD-BE-A-BIG-INT
   :other-things ["I am a vector and also like to place the substitute game"]
   :some-date "so/me/date"}

--- a/src/cprop/source.cljc
+++ b/src/cprop/source.cljc
@@ -24,13 +24,20 @@
                    #(s/replace % dash "-"))
              $)))
 
+(defn- str->num [s]
+  "Convert numeric string into `java.lang.Long` or `clojure.lang.BigInt`"
+  (try
+    (Long/parseLong s)
+    (catch NumberFormatException _
+      (bigint s))))
+
 (defn- str->value [v {:keys [as-is?]}]
   "ENV vars and system properties are strings. str->value will convert:
   the numbers to longs, the alphanumeric values to strings, and will use Clojure reader for the rest
   in case reader can't read OR it reads a symbol, the value will be returned as is (a string)"
   (cond
     as-is? v
-    (re-matches #"[0-9]+" v) (Long/parseLong v)
+    (re-matches #"[0-9]+" v) (str->num v)
     (re-matches #"^(true|false)$" v) (Boolean/parseBoolean v)
     (re-matches #"\w+" v) v
     :else

--- a/test/cprop/test/core.cljc
+++ b/test/cprop/test/core.cljc
@@ -36,6 +36,7 @@
         "IO__HTTP__POOL__CONN_TIMEOUT" "60000"
         "IO__HTTP__POOL__MAX_PER_ROUTE" "10"
         "OTHER_THINGS" "[1 2 3 \"42\"]"
+        "SOME_BIG_INT" "10000000000000000000"
         "SOME_DATE" "7 Nov 22:44:53 2015"}
        (map (fn [[k v]] [(#'cprop.source/env->path k)
                          (#'cprop.source/str->value v opts)]))
@@ -89,6 +90,7 @@
                :max-total 200,
                :max-per-route 10}}},
             :other-things [1 2 3 "42"]
+            :some-big-int 10000000000000000000N
             :some-date 7}  ;; incorrectly parsed substitution (i.e. should have been "7 Nov 22:44:53 2015")
                            ;; next assertion corrects that
            merged))
@@ -110,6 +112,7 @@
                :max-total 200,
                :max-per-route "10"}}},
             :other-things "[1 2 3 \"42\"]"
+            :some-big-int "10000000000000000000"
             :some-date "7 Nov 22:44:53 2015"}
 
            merged-as-is))))
@@ -139,6 +142,7 @@
                :max-total 200,
                :max-per-route :ME-ALSO}}},
             :other-things ["I am a vector and also like to place the substitute game"]
+            :some-big-int :I-SHOULD-BE-A-BIG-INT
             :some-date "so/me/date"}
 
            config))
@@ -176,6 +180,7 @@
                :max-total 200,
                :max-per-route 42}}},
             :other-things ["1" "2" "3" "4" "5" "6" "7"]
+            :some-big-int :I-SHOULD-BE-A-BIG-INT
             :some-date "so/me/date"}
 
            config))))


### PR DESCRIPTION
I had problem with big numeric values from env so i was forced to use `as-is? true` its sadly far from ideal for me, I prepared small fix which use `bigint` if `Long/parseLong` throw exception. Its works for be. Maybe its good enough idea to put it into `cprop` or at least return original value if `Long/parseLong` throw exception.