### PR TITLE
[#33] Add :parse-fn

### DIFF
--- a/README.md
+++ b/README.md
@@ -654,7 +654,7 @@ If you need _ALL_ the properties and configs to come in "as is" (not as EDN) `:a
 ## Custom key-path parsing
 
 By default, `cprop` assumes each part of a processed key-path should be parsed into `keywords`. While this works in many situations, it may be not ideal in others.
-If you need custom parsing you can provide a `:parse-fn` which will be called on each part of a key path:
+If you need custom parsing you can provide a `:key-parse-fn` which will be called on each part of a key path:
 
 ```clojure
 ;; config.edn
@@ -671,8 +671,11 @@ export CLUSTERS__1__PASSWORD=shh-don't-tell
 However, by providing a custom parser you can define the key-path however you would like:
 
 ```clojure
-=> (require '[cprop.souce :as source])
-=> (load-config :parse-fn source/assoc-in-parser)
+=> (def parse-numbers [part]
+     (if (re-matches #"\d+" part)
+       (long part)
+       (keyword part)))
+=> (load-config :key-parse-fn parse-numbers)
 {:clusters [{:name "first" :url "http://somewhere" :password "super-duper-secret"}
             {:name "second" :url "http://elsewhere" :password "shh-don't-tell"}]}
 ```

--- a/README.md
+++ b/README.md
@@ -650,6 +650,31 @@ If you need _ALL_ the properties and configs to come in "as is" (not as EDN) `:a
 
 ```clojure
 (load-config :as-is? true)
+
+## Custom key-path parsing
+
+By default, `cprop` assumes each part of a processed key-path should be parsed into `keywords`. While this works in many situations, it may be not ideal in others.
+If you need custom parsing you can provide a `:parse-fn` which will be called on each part of a key path:
+
+```clojure
+;; config.edn
+{:clusters [{:name "first" :url "http://somewhere" :password nil}
+            {:name "second" :url "http://elsewhere" :password nil}]}
+```
+The following ENV vars wouldn't work since the `0` and `1` are coerced to `keywords`.
+
+```bash
+export CLUSTERS__0__PASSWORD=super-duper-secret
+export CLUSTERS__1__PASSWORD=shh-don't-tell
+```
+
+However, by providing a custom parser you can define the key-path however you would like:
+
+```clojure
+=> (require '[cprop.souce :as source])
+=> (load-config :parse-fn source/assoc-in-parser)
+{:clusters [{:name "first" :url "http://somewhere" :password "super-duper-secret"}
+            {:name "second" :url "http://elsewhere" :password "shh-don't-tell"}]}
 ```
 
 ## Cursors

--- a/dev-resources/fill-me-in.edn
+++ b/dev-resources/fill-me-in.edn
@@ -14,4 +14,6 @@
                      :max-per-route :ME-ALSO}}}
   :some-big-int :I-SHOULD-BE-A-BIG-INT
   :other-things ["I am a vector and also like to place the substitute game"]
-  :some-date "so/me/date"}
+  :some-date "so/me/date"
+  :clusters [{:name "one"
+              :url nil}]}

--- a/dev-resources/overrides.properties
+++ b/dev-resources/overrides.properties
@@ -9,4 +9,6 @@ aws.region=us-east-2
 io.http.pool.conn_timeout=42
 io.http.pool.max_per_route=42
 
+database.aname.password=shh dont tell
+
 other_things=1,2,3,4,5,6,7

--- a/src/cprop/source.cljc
+++ b/src/cprop/source.cljc
@@ -2,7 +2,7 @@
   (:require [clojure.edn :as edn]
             [clojure.string :as s]
             [clojure.java.io :as io]
-            [cprop.tools :refer [contains-in? expand-home with-echo in-debug?]])
+            [cprop.tools :refer [contains-in? expand-home with-echo in-debug? str->num]])
   (:import java.util.MissingResourceException
            java.io.PushbackReader
            java.io.StringReader
@@ -28,13 +28,6 @@
     (s/lower-case $)
     (s/split $ level)
     (map (comp key-parse-fn #(s/replace % dash "-")) $)))
-
-(defn- str->num [s]
-  "Convert numeric string into `java.lang.Long` or `clojure.lang.BigInt`"
-  (try
-    (Long/parseLong s)
-    (catch NumberFormatException _
-      (bigint s))))
 
 (defn- str->value [v {:keys [as-is?]}]
   "ENV vars and system properties are strings. str->value will convert:

--- a/src/cprop/source.cljc
+++ b/src/cprop/source.cljc
@@ -20,14 +20,14 @@
   "Parses the given key by splitting on `level` and replacing `dash` with `-`.
 
   Options:
-    :parse-fn - func that will be called on each part of the split key. Defaults
+    :key-parse-fn - func that will be called on each part of the split key. Defaults
                to `keyword`."
-  [k dash level {:keys [parse-fn]
-                 :or {parse-fn keyword}}]
+  [k dash level {:keys [key-parse-fn]
+                 :or {key-parse-fn keyword}}]
   (as-> k $
     (s/lower-case $)
     (s/split $ level)
-    (map (comp parse-fn #(s/replace % dash "-")) $)))
+    (map (comp key-parse-fn #(s/replace % dash "-")) $)))
 
 (defn- str->num [s]
   "Convert numeric string into `java.lang.Long` or `clojure.lang.BigInt`"
@@ -35,13 +35,6 @@
     (Long/parseLong s)
     (catch NumberFormatException _
       (bigint s))))
-
-(defn assoc-in-parser
-  "Key-part parser that mimics `assoc-in`'s behavior."
-  [part]
-  (if (re-matches #"\d+" part)
-    (str->num part)
-    (keyword part)))
 
 (defn- str->value [v {:keys [as-is?]}]
   "ENV vars and system properties are strings. str->value will convert:

--- a/src/cprop/tools.cljc
+++ b/src/cprop/tools.cljc
@@ -167,3 +167,9 @@
   (when (seq m)
     (flatten-keys* {} [] m)))
 
+(defn parse-num-keys
+  "Key-part parser that parses keywords and integerss"
+  [part]
+  (if (re-matches #"\d+" part)
+    (str->num part)
+    (keyword part)))

--- a/src/cprop/tools.cljc
+++ b/src/cprop/tools.cljc
@@ -167,6 +167,13 @@
   (when (seq m)
     (flatten-keys* {} [] m)))
 
+(defn str->num [s]
+  "Convert numeric string into `java.lang.Long` or `clojure.lang.BigInt`"
+  (try
+    (Long/parseLong s)
+    (catch NumberFormatException _
+      (bigint s))))
+
 (defn parse-num-keys
   "Key-part parser that parses keywords and integerss"
   [part]

--- a/test/cprop/test/core.cljc
+++ b/test/cprop/test/core.cljc
@@ -1,6 +1,7 @@
 (ns cprop.test.core
   (:require [cprop.core :refer [load-config cursor]]
-            [cprop.source :refer [assoc-in-parser merge* from-stream from-file from-resource from-props-file from-env from-system-props]]
+            [cprop.source :refer [merge* from-stream from-file from-resource from-props-file from-env from-system-props]]
+            [cprop.tools :as tools]
             [clojure.edn :as edn]
             [clojure.pprint :as pp]
             [clojure.test :refer :all]))
@@ -74,7 +75,7 @@
                  (slurp "dev-resources/fill-me-in.edn"))
         merged (merge* config (read-test-env {}))
         merged-as-is (merge* config (read-test-env {:as-is? true}))
-        merged-with-custom-parser (merge* config (read-test-env {:parse-fn assoc-in-parser}))]
+        merged-with-custom-parser (merge* config (read-test-env {:key-parse-fn tools/parse-num-keys}))]
 
     (testing "normal parsing"
       (is (= {:datomic {:url "datomic:sql://?jdbc:postgresql://localhost:5432/datomic?user=datomic&password=datomic"},
@@ -249,7 +250,7 @@
         props        (from-system-props)
         props-as-is  (from-system-props {:as-is? true})
         props-with-custom-parser (from-system-props
-                                  {:parse-fn #(case %
+                                  {:key-parse-fn #(case %
                                                 "aname" :parsed
                                                 (keyword %))})]
     (testing "normal parsing"
@@ -289,7 +290,7 @@
   (let [ps (from-props-file "dev-resources/overrides.properties")
         ps-as-is (from-props-file "dev-resources/overrides.properties" {:as-is? true})
         ps-with-custom-parser (from-props-file "dev-resources/overrides.properties"
-                                               {:parse-fn #(case %
+                                               {:key-parse-fn #(case %
                                                              "aname" :parsed
                                                              (keyword %))})]
 


### PR DESCRIPTION
This allows for custom parsing of each part of a key's path. One
example of a use-case is to better match the behavior of
`assoc-in` (i.e \d+ being treated as indices rather than keywords)

- Add new parse-fn to source.cljc
- Add new tests around this option
- Use `testing` instead of comments before `is` forms
- Update README with an example of :parse-fn