### PR TITLE
[#35] Rely on `edn/read-string` for string parsing

### DIFF
--- a/src/cprop/source.cljc
+++ b/src/cprop/source.cljc
@@ -24,30 +24,20 @@
                    #(s/replace % dash "-"))
              $)))
 
-(defn- str->num [s]
-  "Convert numeric string into `java.lang.Long` or `clojure.lang.BigInt`"
-  (try
-    (Long/parseLong s)
-    (catch NumberFormatException _
-      (bigint s))))
-
-(defn- str->value [v {:keys [as-is?]}]
+(defn- str->value
   "ENV vars and system properties are strings. str->value will convert:
   the numbers to longs, the alphanumeric values to strings, and will use Clojure reader for the rest
   in case reader can't read OR it reads a symbol, the value will be returned as is (a string)"
-  (cond
-    as-is? v
-    (re-matches #"[0-9]+" v) (str->num v)
-    (re-matches #"^(true|false)$" v) (Boolean/parseBoolean v)
-    (re-matches #"\w+" v) v
-    :else
+  [v {:keys [as-is?]}]
+  (if as-is?
+    v
     (try
       (let [parsed (edn/read-string {:readers *data-readers*} v)]
         (if (symbol? parsed)
           v
           parsed))
-         (catch Throwable _
-           v))))
+      (catch Throwable _
+        v))))
 
 ;; OS level ENV vars
 

--- a/test/cprop/test/source.cljc
+++ b/test/cprop/test/source.cljc
@@ -1,0 +1,19 @@
+(ns cprop.test.source
+  (:require [cprop.source :as sut]
+            [clojure.test :refer [are deftest testing]]))
+
+(deftest str->value
+  (testing "all data types are handled as expected"
+    (are [input expected] (= expected (#'sut/str->value input {}))
+      "" ""
+      "nil" nil
+      "hello world" "hello world"
+      "-1" -1
+      "1" 1
+      "100000000000000000000" 100000000000000000000
+      "-100000000000000000000" -100000000000000000000
+      "true" true
+      "false" false
+      "#{1 2 3}" #{1 2 3}
+      "[:a :b]" [:a :b]
+      ":keyword" :keyword)))


### PR DESCRIPTION
- The previous regex checks are redundant given `edn/read-string`
  provides the same functionality.